### PR TITLE
Fix: Remove trailing whitespace to pass linting

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3875,8 +3875,8 @@ def _construct_lc_result_from_responses_api(
                         "annotations": [
                             annotation.model_dump()
                             for annotation in content.annotations
-                        ] 
-                        if isinstance(content.annotations, list) 
+                        ]
+                        if isinstance(content.annotations, list)
                         else [],
                         "id": output.id,
                     }


### PR DESCRIPTION
This PR fixes the formatting issues in your PR by removing trailing whitespace on lines 3878-3879.

The CI should pass after merging this fix.